### PR TITLE
Show a cancel button when adding a new account

### DIFF
--- a/Classes/Login/GithubLogin.storyboard
+++ b/Classes/Login/GithubLogin.storyboard
@@ -129,6 +129,7 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
+                        <outlet property="cancelButton" destination="8pk-bv-Eed" id="yQg-Up-uN3"/>
                         <outlet property="onepasswordButton" destination="RD1-5K-AYO" id="izh-i0-FRe"/>
                         <outlet property="passwordTextField" destination="R6o-vG-04h" id="LeG-oC-nTw"/>
                         <outlet property="usernameTextField" destination="ulH-vQ-S5c" id="46x-Gk-rHY"/>

--- a/Classes/Login/GithubLogin.storyboard
+++ b/Classes/Login/GithubLogin.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="FtA-zE-Av4">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="FtA-zE-Av4">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -122,6 +122,11 @@
                     </tableView>
                     <navigationItem key="navigationItem" title="Sign in to GitHub" id="saR-fL-x4s">
                         <barButtonItem key="backBarButtonItem" title="Back" id="rHr-2G-Zin"/>
+                        <barButtonItem key="rightBarButtonItem" systemItem="cancel" id="8pk-bv-Eed">
+                            <connections>
+                                <action selector="onCancel:" destination="4C9-Cb-DoC" id="P0w-d8-7B0"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
                     <connections>
                         <outlet property="onepasswordButton" destination="RD1-5K-AYO" id="izh-i0-FRe"/>

--- a/Classes/Login/LoginRequest.swift
+++ b/Classes/Login/LoginRequest.swift
@@ -12,6 +12,7 @@ enum GithubLogin {
     case failed(Error?)
     case success(Authorization)
     case twoFactor
+    case cancelled
 }
 
 private func base64Auth(username: String, password: String) -> String {

--- a/Classes/Login/LoginViewController.swift
+++ b/Classes/Login/LoginViewController.swift
@@ -113,6 +113,15 @@ final class LoginViewController: UITableViewController, UITextFieldDelegate {
             navigationItem.rightBarButtonItem = nil
         }
     }
+    
+    override func accessibilityPerformEscape() -> Bool {
+        if isInitialLogin {
+            return false
+        } else {
+            handleResult(.cancelled, login: "")
+            return true
+        }
+    }
 
     // MARK: UITextFieldDelegate
 

--- a/Classes/Login/LoginViewController.swift
+++ b/Classes/Login/LoginViewController.swift
@@ -12,6 +12,7 @@ import OnePasswordExtension
 final class LoginViewController: UITableViewController, UITextFieldDelegate {
 
     var client: GithubClient!
+    var isInitialLogin: Bool = true
 
     let signinCellIndexPath = IndexPath(item: 0, section: 2)
 
@@ -27,6 +28,9 @@ final class LoginViewController: UITableViewController, UITextFieldDelegate {
         super.viewDidLoad()
         onepasswordButton.setImage(onePasswordButtonImage(), for: .normal)
         onepasswordButton.isHidden = !onePasswordAvailable()
+        if isInitialLogin {
+            navigationItem.rightBarButtonItems = []
+        }
     }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
@@ -52,6 +56,11 @@ final class LoginViewController: UITableViewController, UITextFieldDelegate {
             case .cancelled: break
             }
         }
+    }
+    
+    @IBAction func onCancel(_ sender: Any) {
+        guard !isInitialLogin else { fatalError("Should not be able to cancel during initial login") }
+        handleResult(.cancelled, login: "")
     }
 
     func viewsEnabled(_ enabled: Bool) {
@@ -92,6 +101,8 @@ final class LoginViewController: UITableViewController, UITextFieldDelegate {
             showAlert(title: title, message: message)
         case .twoFactor:
             performSegue(withIdentifier: "show2fac", sender: nil)
+        case .cancelled:
+            client.sessionManager.cancel()
         }
     }
 

--- a/Classes/Login/LoginViewController.swift
+++ b/Classes/Login/LoginViewController.swift
@@ -19,6 +19,7 @@ final class LoginViewController: UITableViewController, UITextFieldDelegate {
     @IBOutlet weak var usernameTextField: UITextField!
     @IBOutlet weak var passwordTextField: UITextField!
     @IBOutlet weak var onepasswordButton: UIButton!
+    @IBOutlet var cancelButton: UIBarButtonItem!
 
     var textFields: [UITextField] {
         return [usernameTextField, passwordTextField]
@@ -28,9 +29,7 @@ final class LoginViewController: UITableViewController, UITextFieldDelegate {
         super.viewDidLoad()
         onepasswordButton.setImage(onePasswordButtonImage(), for: .normal)
         onepasswordButton.isHidden = !onePasswordAvailable()
-        if isInitialLogin {
-            navigationItem.rightBarButtonItems = []
-        }
+        showCancelButton(!isInitialLogin)
     }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
@@ -86,6 +85,7 @@ final class LoginViewController: UITableViewController, UITextFieldDelegate {
 
         client.requestGithubLogin(username: username, password: password) { result in
             self.showLoadingIndicator(false)
+            self.showCancelButton(!self.isInitialLogin)
             self.viewsEnabled(true)
             self.handleResult(result, login: username)
         }
@@ -103,6 +103,14 @@ final class LoginViewController: UITableViewController, UITextFieldDelegate {
             performSegue(withIdentifier: "show2fac", sender: nil)
         case .cancelled:
             client.sessionManager.cancel()
+        }
+    }
+    
+    func showCancelButton(_ show: Bool) {
+        if show {
+            navigationItem.rightBarButtonItem = cancelButton
+        } else {
+            navigationItem.rightBarButtonItem = nil
         }
     }
 

--- a/Classes/Settings/SettingsAddAccountSectionController.swift
+++ b/Classes/Settings/SettingsAddAccountSectionController.swift
@@ -35,7 +35,7 @@ final class SettingsAddAccountSectionController: ListSectionController {
     }
 
     override func didSelectItem(at index: Int) {
-        rootNavigationManager.showLogin(animated: true)
+        rootNavigationManager.showLogin(animated: true, isInitialLogin: false)
     }
 
 }

--- a/Classes/Settings/SettingsViewController.swift
+++ b/Classes/Settings/SettingsViewController.swift
@@ -89,5 +89,9 @@ final class SettingsViewController: UIViewController, ListAdapterDataSource, Git
     func didRemove(manager: GithubSessionManager, userSessions: [GithubUserSession], result: GithubSessionResult) {
         adapter.performUpdates(animated: false)
     }
+    
+    func didCancel(manager: GithubSessionManager) {
+        // No-op; no updates needed
+    }
 
 }

--- a/Classes/Systems/GithubSessionManager.swift
+++ b/Classes/Systems/GithubSessionManager.swift
@@ -18,6 +18,7 @@ enum GithubSessionResult {
 protocol GithubSessionListener: class {
     func didFocus(manager: GithubSessionManager, userSession: GithubUserSession)
     func didRemove(manager: GithubSessionManager, userSessions: [GithubUserSession], result: GithubSessionResult)
+    func didCancel(manager: GithubSessionManager)
 }
 
 extension GithubUserSession {
@@ -80,6 +81,12 @@ final class GithubSessionManager: NSObject, ListDiffable {
         save()
         for wrapper in listeners {
             wrapper.listener?.didFocus(manager: self, userSession: userSession)
+        }
+    }
+    
+    public func cancel() {
+        for wrapper in listeners {
+            wrapper.listener?.didCancel(manager: self)
         }
     }
 

--- a/Classes/Systems/RootNavigationManager.swift
+++ b/Classes/Systems/RootNavigationManager.swift
@@ -30,7 +30,7 @@ final class RootNavigationManager: GithubSessionListener {
 
     // MARK: Public API
 
-    public func showLogin(animated: Bool = false) {
+    public func showLogin(animated: Bool = false, isInitialLogin: Bool = true) {
         guard showingLogin == false,
             let nav = UIStoryboard(
                 name: "GithubLogin",
@@ -40,6 +40,7 @@ final class RootNavigationManager: GithubSessionListener {
             else { return }
         showingLogin = true
         login.client = newGithubClient(sessionManager: sessionManager)
+        login.isInitialLogin = isInitialLogin
         rootTabBarController?.present(nav, animated: animated)
     }
 
@@ -71,6 +72,11 @@ final class RootNavigationManager: GithubSessionListener {
         case .logout: showLogin(animated: true)
         case .unchanged: break
         }
+    }
+    
+    func didCancel(manager: GithubSessionManager) {
+        showingLogin = false
+        rootTabBarController?.presentedViewController?.dismiss(animated: true)
     }
 
 }


### PR DESCRIPTION
This adds a "cancel" button when adding new account. Without this, the user would get stuck when adding a new account and not being able to finish the flow.