### PR TITLE
Add clearer accessibility labels and traits

### DIFF
--- a/Classes/Issues/Comments/Details/IssueCommentDetailCell.swift
+++ b/Classes/Issues/Comments/Details/IssueCommentDetailCell.swift
@@ -63,6 +63,7 @@ final class IssueCommentDetailCell: UICollectionViewCell, ListBindable {
         moreButton.contentVerticalAlignment = UIControlContentVerticalAlignment.center
         moreButton.tintColor = Styles.Colors.Gray.light.color
         moreButton.addTarget(self, action: #selector(IssueCommentDetailCell.onMore), for: .touchUpInside)
+        moreButton.accessibilityLabel = NSLocalizedString("More options", comment: "")
         contentView.addSubview(moreButton)
         moreButton.snp.makeConstraints { make in
             make.size.equalTo(Styles.Sizes.icon)

--- a/Classes/Issues/Comments/Reactions/IssueCommentReactionCell.swift
+++ b/Classes/Issues/Comments/Reactions/IssueCommentReactionCell.swift
@@ -47,6 +47,7 @@ UICollectionViewDelegateFlowLayout {
         addButton.semanticContentAttribute = .forceRightToLeft
         addButton.setImage(UIImage(named: "smiley-small")?.withRenderingMode(.alwaysTemplate), for: .normal)
         addButton.addTarget(self, action: #selector(IssueCommentReactionCell.onAddButton), for: .touchUpInside)
+        addButton.accessibilityLabel = NSLocalizedString("Add reaction", comment: "")
         contentView.addSubview(addButton)
         addButton.snp.makeConstraints { make in
             make.left.equalTo(Styles.Sizes.gutter)

--- a/Classes/Settings/SettingsUserCell.swift
+++ b/Classes/Settings/SettingsUserCell.swift
@@ -19,6 +19,7 @@ final class SettingsUserCell: UICollectionViewCell, ListBindable {
         super.init(frame: frame)
 
         contentView.backgroundColor = .white
+        accessibilityTraits |= UIAccessibilityTraitButton
 
         label.backgroundColor = .clear
         label.textAlignment = .left
@@ -52,6 +53,11 @@ final class SettingsUserCell: UICollectionViewCell, ListBindable {
         guard let viewModel = viewModel as? SettingsUserModel else { return }
         label.text = viewModel.name
         accessoryView.isHidden = !viewModel.selected
+        
+        let format = NSLocalizedString("%@, %@ account", comment: "") // eg. "rnystrom, selected account"
+        accessibilityLabel = .localizedStringWithFormat(format,
+                                                        viewModel.name,
+                                                        (viewModel.selected) ? NSLocalizedString("selected", comment: "") : "")
     }
 
 }

--- a/Classes/Settings/SettingsViewController.swift
+++ b/Classes/Settings/SettingsViewController.swift
@@ -64,6 +64,13 @@ final class SettingsViewController: UIViewController, ListAdapterDataSource, Git
             action: #selector(SettingsViewController.onDone)
         )
     }
+    
+    // MARK: Accessibility
+    
+    override func accessibilityPerformEscape() -> Bool {
+        onDone()
+        return true
+    }
 
     // MARK: Private API
 

--- a/Classes/Systems/RootNavigationManager.swift
+++ b/Classes/Systems/RootNavigationManager.swift
@@ -48,12 +48,14 @@ final class RootNavigationManager: GithubSessionListener {
         let client = newGithubClient(sessionManager: sessionManager, userSession: userSession)
 
         let notifications = newNotificationsRootViewController(client: client)
-        notifications.navigationItem.leftBarButtonItem = UIBarButtonItem(
+        let settingsBarButtonItem = UIBarButtonItem(
             image: UIImage(named: "bullets-hollow"),
             style: .plain,
             target: self,
             action: #selector(RootNavigationManager.onSettings)
         )
+        settingsBarButtonItem.accessibilityLabel = NSLocalizedString("Settings", comment: "")
+        notifications.navigationItem.leftBarButtonItem = settingsBarButtonItem
 
         masterNavigationController?.viewControllers = [notifications]
     }

--- a/Classes/Views/ButtonCell.swift
+++ b/Classes/Views/ButtonCell.swift
@@ -20,6 +20,7 @@ final class ButtonCell: UICollectionViewCell {
         super.init(frame: frame)
 
         contentView.backgroundColor = .white
+        accessibilityTraits |= UIAccessibilityTraitButton
 
         topSeparator = contentView.addBorder(bottom: false, left: 0, right: 0)
         bottomSeparator = contentView.addBorder(bottom: true, left: 0, right: 0)

--- a/Classes/Views/UIButton+Label.swift
+++ b/Classes/Views/UIButton+Label.swift
@@ -11,6 +11,7 @@ import UIKit
 extension UIButton {
 
     func setupAsLabel() {
+        accessibilityTraits = UIAccessibilityTraitNone
         tintColor = .white
         titleLabel?.font = Styles.Fonts.smallTitle
         layer.cornerRadius = Styles.Sizes.avatarCornerRadius

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>127</string>
+	<string>138</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>org-appextension-feature-password-management</string>


### PR DESCRIPTION
What these changes do:

- Make the "more options" button in an issue / PR be called "More options" instead of "bullet"
- Make the "add reaction" button in a comment be called "Add reaction" instead of "plus"
- Add a button trait to both `SettingsUserCell` and `ButtonCell` to indicate these are buttons
- Make the user cell in settings make clear this is an account, and tell us when it is selected (or not)
- Make the SettingsVC dismissible with a two-finger Z-swipe in VoiceOver mode.
- Make the "settings" button be called "Settings" instead of "bullets hollow"
- Remove the button trait from buttons used as labels (eg. the "merged" / "open" / "closed" images)