### PR TITLE
[minor] Update alert text

### DIFF
--- a/Classes/Notifications/NotificationsViewController.swift
+++ b/Classes/Notifications/NotificationsViewController.swift
@@ -91,7 +91,7 @@ NotificationNextPageSectionControllerDelegate {
             preferredStyle: .alert
         )
         let markAll = UIAlertAction(
-            title: NSLocalizedString("Mark all", comment: ""),
+            title: NSLocalizedString("OK", comment: ""),
             style: .default
         ) { _ in
             self.markAllRead()

--- a/Classes/Notifications/NotificationsViewController.swift
+++ b/Classes/Notifications/NotificationsViewController.swift
@@ -91,7 +91,7 @@ NotificationNextPageSectionControllerDelegate {
             preferredStyle: .alert
         )
         let markAll = UIAlertAction(
-            title: NSLocalizedString("OK", comment: ""),
+            title: NSLocalizedString("Mark All Read", comment: ""),
             style: .default
         ) { _ in
             self.markAllRead()

--- a/Classes/View Controllers/UIViewController+Alerts.swift
+++ b/Classes/View Controllers/UIViewController+Alerts.swift
@@ -12,7 +12,7 @@ extension UIViewController {
 
     func showAlert(title: String, message: String) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        let action = UIAlertAction(title: NSLocalizedString("Ok", comment: ""), style: .default, handler: nil)
+        let action = UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .default, handler: nil)
         alert.addAction(action)
         present(alert, animated: true, completion: nil)
     }

--- a/Classes/View Controllers/UIViewController+Alerts.swift
+++ b/Classes/View Controllers/UIViewController+Alerts.swift
@@ -12,7 +12,7 @@ extension UIViewController {
 
     func showAlert(title: String, message: String) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        let action = UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .default, handler: nil)
+        let action = UIAlertAction(title: Strings.ok, style: .default, handler: nil)
         alert.addAction(action)
         present(alert, animated: true, completion: nil)
     }

--- a/Classes/Views/Strings.swift
+++ b/Classes/Views/Strings.swift
@@ -12,7 +12,7 @@ struct Strings {
 
     static let all = NSLocalizedString("All", comment: "")
     static let unread = NSLocalizedString("Unread", comment: "")
-    static let ok = NSLocalizedString("Ok", comment: "")
+    static let ok = NSLocalizedString("OK", comment: "")
     static let cancel = NSLocalizedString("Cancel", comment: "")
     static let signout = NSLocalizedString("Sign out", comment: "")
     static let open = NSLocalizedString("Open", comment: "")


### PR DESCRIPTION
I found the "Mark All" alert a bit strange.. this pull requests changes that to "OK" instead

From https://developer.apple.com/ios/human-interface-guidelines/ui-views/alerts/
> Give alert buttons succinct, logical titles. The best button titles consist of one or two words that describe the result of selecting the button. As with all button titles, use title-style capitalization and no ending punctuation. To the extent possible, use verbs and verb phrases that relate directly to the alert title and message—for example, View All, Reply, or Ignore. Use OK for simple acceptance. 

Also this changes "Ok" to "OK" in other places

Thx for the app!