### PR TITLE
Update to use Apple's ISO8601 Date Formatter

### DIFF
--- a/Classes/Systems/GithubAPIDateFormatter.swift
+++ b/Classes/Systems/GithubAPIDateFormatter.swift
@@ -8,9 +8,8 @@
 
 import Foundation
 
-private let dateFormatter = DateFormatter()
-func GithubAPIDateFormatter() -> DateFormatter {
+private let dateFormatter = ISO8601DateFormatter()
+func GithubAPIDateFormatter() -> ISO8601DateFormatter {
     // https://developer.github.com/v3/#schema
-    dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
     return dateFormatter
 }

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>700</string>
+	<string>704</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>


### PR DESCRIPTION
Fixes #64
I also think this may fix #22

So originally I was just going to add the locale and timeZone properties as per Apple's documentation [here](https://developer.apple.com/documentation/foundation/dateformatter#2528261). But then I realised we only support iOS 10+, and that gives us access to the new [`ISO8601DateFormatter`](https://developer.apple.com/documentation/foundation/iso8601dateformatter)

I gave the app a cursory glance in both 12hr and 24hr modes and it does appear to be working?

The alternative (if we wanted iOS 9 support, or if someone finds further issues with this) is, for reference:
``` swift
dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
dateFormatter.locale = Locale(identifier: "en_US_POSIX")
dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
dateFormatter.calendar = Calendar(identifier: .iso8601)
```