### PR TITLE
Fixed retain cycle related to AttributedStringView

### DIFF
--- a/Classes/Views/AttributedStringView.swift
+++ b/Classes/Views/AttributedStringView.swift
@@ -15,7 +15,7 @@ protocol AttributedStringViewDelegate: class {
 
 final class AttributedStringView: UIView {
 
-    var delegate: AttributedStringViewDelegate? = nil
+    weak var delegate: AttributedStringViewDelegate? = nil
 
     private var text: NSAttributedStringSizing? = nil
 


### PR DESCRIPTION
Most notably caused IssuesViewController to be retained after
dismissing.