### PR TITLE
Added notification title constraint, close #162

### DIFF
--- a/Classes/Notifications/NotificationCell.swift
+++ b/Classes/Notifications/NotificationCell.swift
@@ -46,6 +46,7 @@ final class NotificationCell: SwipeSelectableCell {
         dateLabel.snp.makeConstraints { make in
             make.right.equalTo(-Styles.Sizes.gutter)
             make.centerY.equalTo(titleLabel)
+            make.left.equalTo(titleLabel.snp.right).offset(Styles.Sizes.gutter)
         }
 
         reasonImageView.backgroundColor = .clear


### PR DESCRIPTION
Issue #162
Before: 
<img width="603" alt="screen_shot_2017-07-17_at_9_30_16_pm" src="https://user-images.githubusercontent.com/3388381/28296967-42b01236-6b39-11e7-83ad-680c26db6023.png">

After: 
<img width="607" alt="screen_shot_2017-07-17_at_9_44_34_pm" src="https://user-images.githubusercontent.com/3388381/28296969-47798b58-6b39-11e7-84f8-8757c0238493.png">
