### PR TITLE
[WIP] Add list of reactors on long press

### DIFF
--- a/Classes/Issues/Comments/Reactions/IssueCommentReactionCell.swift
+++ b/Classes/Issues/Comments/Reactions/IssueCommentReactionCell.swift
@@ -156,6 +156,23 @@ UICollectionViewDelegateFlowLayout {
         let model = reactions[indexPath.item]
         cell.label.text = "\(model.content.emoji) \(model.count)"
         cell.contentView.backgroundColor = model.viewerDidReact ? Styles.Colors.Blue.light.color : .clear
+        
+        var users = model.users
+        guard users.count > 0 else { return cell }
+        
+        let difference = model.count - users.count
+        if difference > 0 {
+            let format = NSLocalizedString("%d other(s) reacted", comment: "")
+            users.append(String.localizedStringWithFormat(format, difference))
+        }
+        
+        let lastUser = users.removeLast()
+        var message = users.joined(separator: ", ")
+        message += users.count > 0 ? " and " + lastUser : lastUser
+        message += " reacted"
+        
+        cell.label.detailText = message
+        
         return cell
     }
 
@@ -180,5 +197,5 @@ UICollectionViewDelegateFlowLayout {
             delegate?.didAdd(cell: self, reaction: model.content)
         }
     }
-
+    
 }

--- a/Classes/Issues/Comments/Reactions/IssueReactionCell.swift
+++ b/Classes/Issues/Comments/Reactions/IssueReactionCell.swift
@@ -11,7 +11,7 @@ import SnapKit
 
 final class IssueReactionCell: UICollectionViewCell {
 
-    let label = UILabel()
+    let label = ShowMoreDetailsLabel()
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Classes/Issues/Comments/Reactions/ReactionViewModel.swift
+++ b/Classes/Issues/Comments/Reactions/ReactionViewModel.swift
@@ -13,5 +13,6 @@ struct ReactionViewModel {
     let content: ReactionContent
     let count: Int
     let viewerDidReact: Bool
+    let users: [String]
 
 }

--- a/Classes/Issues/IssueViewModels.swift
+++ b/Classes/Issues/IssueViewModels.swift
@@ -62,7 +62,16 @@ func createIssueReactions(reactions: ReactionFields) -> IssueCommentReactionView
         // do not display reactions for 0 count
         let count = group.users.totalCount
         guard count > 0 else { continue }
-        models.append(ReactionViewModel(content: group.content, count: count, viewerDidReact: group.viewerHasReacted))
+        
+        let nodes: [String] = {
+            guard let filtered = group.users.nodes?.filter({ $0?.login != nil }) as? [ReactionFields.ReactionGroup.User.Node] else {
+                return []
+            }
+            
+            return filtered.map({ $0.login })
+        }()
+        
+        models.append(ReactionViewModel(content: group.content, count: count, viewerDidReact: group.viewerHasReacted, users: nodes))
     }
 
     return IssueCommentReactionViewModel(models: models)

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>932</string>
+	<string>933</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/Resources/Localizable.stringsdict
+++ b/Resources/Localizable.stringsdict
@@ -2,6 +2,30 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>%d other(s) reacted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@others@</string>
+		<key>others</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string></string>
+			<key>one</key>
+			<string>1 other</string>
+			<key>two</key>
+			<string></string>
+			<key>few</key>
+			<string></string>
+			<key>many</key>
+			<string></string>
+			<key>other</key>
+			<string>%d others</string>
+		</dict>
+	</dict>
 	<key>%d minute(s) ago</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/gql/API.swift
+++ b/gql/API.swift
@@ -2577,8 +2577,12 @@ public struct ReactionFields: GraphQLNamedFragment {
     "  reactionGroups {" +
     "    __typename" +
     "    viewerHasReacted" +
-    "    users {" +
+    "    users(first: 3) {" +
     "      __typename" +
+    "      nodes {" +
+    "        __typename" +
+    "        login" +
+    "      }" +
     "      totalCount" +
     "    }" +
     "    content" +
@@ -2611,18 +2615,32 @@ public struct ReactionFields: GraphQLNamedFragment {
     public init(reader: GraphQLResultReader) throws {
       __typename = try reader.value(for: Field(responseName: "__typename"))
       viewerHasReacted = try reader.value(for: Field(responseName: "viewerHasReacted"))
-      users = try reader.value(for: Field(responseName: "users"))
+      users = try reader.value(for: Field(responseName: "users", arguments: ["first": 3]))
       content = try reader.value(for: Field(responseName: "content"))
     }
 
     public struct User: GraphQLMappable {
       public let __typename: String
+      /// A list of nodes.
+      public let nodes: [Node?]?
       /// Identifies the total count of items in the connection.
       public let totalCount: Int
 
       public init(reader: GraphQLResultReader) throws {
         __typename = try reader.value(for: Field(responseName: "__typename"))
+        nodes = try reader.optionalList(for: Field(responseName: "nodes"))
         totalCount = try reader.value(for: Field(responseName: "totalCount"))
+      }
+
+      public struct Node: GraphQLMappable {
+        public let __typename: String
+        /// The username used to login.
+        public let login: String
+
+        public init(reader: GraphQLResultReader) throws {
+          __typename = try reader.value(for: Field(responseName: "__typename"))
+          login = try reader.value(for: Field(responseName: "login"))
+        }
       }
     }
   }

--- a/gql/Fragments.graphql
+++ b/gql/Fragments.graphql
@@ -2,7 +2,10 @@ fragment reactionFields on Reactable {
   viewerCanReact
   reactionGroups {
     viewerHasReacted
-    users {
+    users(first: 3) {
+      nodes {
+        login
+      }
       totalCount
     }
     content


### PR DESCRIPTION
Supersedes #138 

Working on fixing up branch

-- Old PR --
Closes #66

Took me way too long to work out how GQL works 😅 Yes, I changed API.swift multiple times and was confused why it was being deleted until I read the comment where it says it's auto generated.

Supports multiple outputs, as such:
"x reacted with heart emoji"
"x and y reacted with heart emoji"
"x, y and z reacted with heart emoji"
"x, y, z and 1 other reacted with heart emoji"
"x, y, z and 15 others reacted with heart emoji"

There's a limit of 10 names before it adds the "and x other(s)" logic, this was plucked out of the air and is simply to prevent the list from getting huge!

You get something like this:
![Preview](https://image.prntscr.com/image/f7qwm2ZuT7yJ5TeWWNdaNw.png)