### PR TITLE
Change Secret keys to Xcode Text Placeholders

### DIFF
--- a/Classes/Other/Secrets.swift
+++ b/Classes/Other/Secrets.swift
@@ -10,7 +10,8 @@ import Foundation
 
 public enum GithubAPI {
 
-    static let clientID = "YOUR_CLIENT_ID"
-    static let clientSecret = "YOUR_CLIENT_SECRET"
+    // See https://github.com/rnystrom/Freetime/blob/master/Setup.md
+    static let clientID = <#YOUR CLIENT ID#>
+    static let clientSecret = <#YOUR CLIENT SECRET#>
 
 }


### PR DESCRIPTION
* The project won’t compile until the developer updates with their own keys.
* Added comment to documentation about setting up the keys.