### PR TITLE
Changed maximumNumberOfLines to Int from UInt

### DIFF
--- a/TextViews.playground/Contents.swift
+++ b/TextViews.playground/Contents.swift
@@ -13,7 +13,7 @@ struct SizableAttributedString {
 
     // NSTextContainer
     let exclusionPaths: [UIBezierPath]
-    let maximumNumberOfLines: UInt
+    let maximumNumberOfLines: Int
     let lineFragmentPadding: CGFloat
 
     // NSLayoutManager
@@ -28,7 +28,7 @@ struct SizableAttributedString {
         attributedText: NSAttributedString,
         inset: UIEdgeInsets = .zero,
         exclusionPaths: [UIBezierPath] = [],
-        maximumNumberOfLines: UInt = 0,
+        maximumNumberOfLines: Int = 0,
         lineFragmentPadding: CGFloat = 0.0,
         allowsNonContiguousLayout: Bool = false,
         hyphenationFactor: CGFloat = 0.0,


### PR DESCRIPTION
This fixes the playground errors and keeps the maximumNumberOfLines
property type consistent with maximumNumberOfLines on NSTextContainer.